### PR TITLE
Tell preflight to look for docker toolbox

### DIFF
--- a/scripts/preflight
+++ b/scripts/preflight
@@ -13,7 +13,7 @@ fi
 sleep 1
 
 # look for DOCKER_HOST too?
-if [ "${BOOT2DOCKER}x" = "0x" ] ;then
+if [ "${DOCKER_HOST}x" = "0x" ] ;then
   echo "Checking that we can reach server on localhost"
   if [ $(curl -s localhost:8888 |grep -c Thank) -eq 0 ] ;then
     echo "Failed to start test server.  Is docker working"

--- a/scripts/preflight
+++ b/scripts/preflight
@@ -12,6 +12,7 @@ if [ $? -ne 0 ] ;then
 fi
 sleep 1
 
+# look for DOCKER_HOST too?
 if [ "${BOOT2DOCKER}x" = "0x" ] ;then
   echo "Checking that we can reach server on localhost"
   if [ $(curl -s localhost:8888 |grep -c Thank) -eq 0 ] ;then


### PR DESCRIPTION
Please do not merge yet!

I think that line 16 is trying to determine whether boot2docker is available, and if not, then run the curl to localhost.  With boot2docker being rolled in to Docker Toolbox, that environment variable no longer exists.  I want to check for DOCKER_HOST as well.
